### PR TITLE
fix: retrieve routes in test environment

### DIFF
--- a/providers/izzy_provider.ts
+++ b/providers/izzy_provider.ts
@@ -8,7 +8,7 @@
 import type { ApplicationService, HttpRouterService } from '@adonisjs/core/types'
 import type { SerializedRoute } from '../src/types/manifest.js'
 import { serializeRoute } from '../src/serialize_route.js'
-import { RouteJSON } from '@adonisjs/core/types/http'
+import type { RouteJSON } from '@adonisjs/core/types/http'
 
 declare global {
   namespace globalThis {

--- a/providers/izzy_provider.ts
+++ b/providers/izzy_provider.ts
@@ -73,7 +73,7 @@ export default class IzzyRouteProvider {
 
   #routesToJSON(routes: (Route | RouteResource | RouteGroup | BriskRoute)[]): RouteJSON[] {
     return routes
-      .flatMap((route) => {
+      .map((route) => {
         if ('route' in route) {
           return route.route?.toJSON()
         }
@@ -85,6 +85,7 @@ export default class IzzyRouteProvider {
         return route.toJSON()
       })
       .filter((route): route is RouteJSON => route !== null)
+      .flat(Number.POSITIVE_INFINITY)
   }
 
   /**

--- a/providers/izzy_provider.ts
+++ b/providers/izzy_provider.ts
@@ -5,9 +5,10 @@
  * For the full license information, please view the LICENSE file that was distributed with this source code.
  */
 
-import type { ApplicationService } from '@adonisjs/core/types'
+import type { ApplicationService, HttpRouterService } from '@adonisjs/core/types'
 import type { SerializedRoute } from '../src/types/manifest.js'
 import { serializeRoute } from '../src/serialize_route.js'
+import { RouteJSON } from '@adonisjs/core/types/http'
 
 declare global {
   namespace globalThis {
@@ -39,12 +40,38 @@ export default class IzzyRouteProvider {
       })
     }
 
+    if (routesJSON.length === 0) {
+      routesJSON = await this.#getTestRoutes(router)
+    }
+
     const exists = routesJSON.find((route) => route.domain === 'root')
 
     if (exists) {
       this.#registerSsrRoutes(exists.routes)
       await this.#registerEdgePlugin(exists.routes)
     }
+  }
+
+  async #getTestRoutes(router: HttpRouterService) {
+    const routes = router.routes
+      .map((route) =>
+        'route' in route ? route.route?.toJSON() : 'toJSON' in route ? route.toJSON() : null
+      )
+      .filter((route): route is RouteJSON => route !== null)
+    const domains = [...new Set(routes.map((route) => route.domain)).values()]
+    const routesJSON: { domain: string; routes: SerializedRoute[] }[] = []
+
+    for (let domain of domains) {
+      const domainRoutes = routes.filter((route) => route.domain === domain)
+      const serializedDomainRoutes = await Promise.all(domainRoutes.map(serializeRoute))
+
+      routesJSON.push({
+        domain,
+        routes: serializedDomainRoutes,
+      })
+    }
+
+    return routesJSON
   }
 
   /**


### PR DESCRIPTION
When I ran tests on my app, I noticed that the `@routes()` tag wasn't being handled as expected. This caused the tests to fail (you can find the details at https://github.com/lahgolz/izzyjs-test). I noticed that the routes are stored elsewhere in the router, so if it can't find them in the first place, it will look for them.